### PR TITLE
fetch Keycloak config from server again

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import { useEffect, useState } from "react";
 import userContext from "./context/userContext";
 import SubjectSelectionContext from "./context/subjectSelectionContext";
 import Keycloak from "keycloak-js";
-import { URLS, KEYCLOAK_CONFIG, MASTER_MAJORS, COURSE_CATALOGUE } from "./server_constants";
+import { URLS } from "./server_constants";
 
 function App() {
     const [user, setUser] = useState<Keycloak.KeycloakInstance | null>(null);
@@ -29,11 +29,10 @@ function App() {
 
     useEffect(() => {
         const createKeycloak = async () => {
-            const keycloak = Keycloak(KEYCLOAK_CONFIG);
+            const keycloak = Keycloak("/keycloak.json");
 
             await keycloak.init({
                 onLoad: "login-required",
-                redirectUri: "http://localhost:3000",
             });
             setKeycloak(keycloak);
             setAuthenticated(keycloak.authenticated);

--- a/frontend/src/server_constants.ts
+++ b/frontend/src/server_constants.ts
@@ -12,9 +12,3 @@ export const COURSE_CATALOGUE = {
     BACHELOR: "https://cloud.hs-augsburg.de/s/e6bYJTCP4JQ5RXj",
     MASTER: "https://cloud.hs-augsburg.de/s/a7TnPfxtmXbxTcD",
   };
-  
-export const KEYCLOAK_CONFIG = {
-    realm: "hsa",
-    url: "http://localhost:8080/auth/",
-    clientId: "wpf-rest-api",
-  };


### PR DESCRIPTION
The keycloak config cant be hardcoded and must be fetched from the `keycloak.json` file. Otherwise we end up with hardcoded urls and an application that cant be deployed anywhere.