### PR TITLE
Fix subject view

### DIFF
--- a/frontend/src/components/SubjectCardView.tsx
+++ b/frontend/src/components/SubjectCardView.tsx
@@ -71,7 +71,7 @@ function SubjectCardView(props: SubjectCardViewProps) {
         SubjectSelectionContext
     ) || {};
 
-    if (!subjectSelection || !setSubjectSelection) {
+    if (!setSubjectSelection) {
         return <></>;
     }
 

--- a/frontend/src/components/SubjectCardView.tsx
+++ b/frontend/src/components/SubjectCardView.tsx
@@ -1,5 +1,4 @@
-import { URLS } from "@/server_constants";
-import { useNavigate, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import React, { useContext } from "react";
 import SubjectSelectionContext from "../context/subjectSelectionContext";
 
@@ -64,9 +63,6 @@ interface SubjectCardViewProps {
 }
 
 function SubjectCardView(props: SubjectCardViewProps) {
-    let navigate = useNavigate();
-    const location = useLocation();
-
     const { subjectSelection, setSubjectSelection } = useContext(
         SubjectSelectionContext
     ) || {};
@@ -74,24 +70,6 @@ function SubjectCardView(props: SubjectCardViewProps) {
     if (!setSubjectSelection) {
         return <></>;
     }
-
-    /**
-     * Handle clicks on a subject title.
-     * @param {MouseEvent} e Instance of the mouse event.
-     */
-    const handleSubjectClick = (e: React.SyntheticEvent) => {
-        const link = props.subject.replace(" ", "_");
-        console.log(
-            `[SubjectCardView][handleSubjectClick] clicked on the subject ${link}!`
-        );
-        navigate(`${URLS.SUBJECTS}/${link}`, {
-            state: {
-                subject: props,
-                prevPath: location.pathname,
-            },
-        });
-        e.preventDefault();
-    };
 
     /**
      * Handle clicks on the register/unregister button of a subject card. Opens the subject detail page.
@@ -126,9 +104,11 @@ function SubjectCardView(props: SubjectCardViewProps) {
         <div className="col">
             <div className="card">
                 <div className="card-body subject-card">
-                    <h5 className="card-title" onClick={(e) => handleSubjectClick(e)}>
-                        {props.subject}
-                    </h5>
+                    <Link to={props.id}>
+                        <h5 className="card-title">
+                            {props.subject}
+                        </h5>
+                    </Link>
                     <h6 className="card-subtitle">
                         {props.professor} | {props.creditPoints} CP
                     </h6>

--- a/frontend/src/components/layout/Pagination.tsx
+++ b/frontend/src/components/layout/Pagination.tsx
@@ -33,7 +33,7 @@ function Pagination(props: PaginationProps) {
     const [currentPage, setCurrentPage] = useState(1);
     const { subjectSelection, setSubjectSelection } = useContext(SubjectSelectionContext) || {};
 
-    if (!subjectSelection || !setSubjectSelection) {
+    if (!setSubjectSelection) {
         return <></>;
     }
 

--- a/frontend/src/components/pages/SubjectDetail.tsx
+++ b/frontend/src/components/pages/SubjectDetail.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import React, { useContext, useEffect, useState } from "react";
 import userContext from "../../context/userContext";
 import { SubjectControllerApi, SubjectTO } from "../../api";
@@ -43,7 +43,7 @@ function SubjectDetail(props: SubjectDetailProps) {
                 getRequestHeaders(user)
             );
             const subject = subjectResponse.data.find(
-                (s) => s.name === subjectName
+                (s) => s.id === subjectName
             );
             setSubject(subject);
         };
@@ -66,14 +66,15 @@ function SubjectDetail(props: SubjectDetailProps) {
             <div className="container main">
                 <div className="row" style={{ marginBottom: "0.75em" }}>
                     <p style={{ color: "#F00045" }}>
-                        <a href="." onClick={(e) => goBack(e)}>
-                            {previousPath
-                                ? PREVIOUS_PATH_MAP[previousPath]
-                                : PREVIOUS_PATH_MAP["/subjects"]}
-                        </a>{" "}
-                        / <a href="/">{subjectName}</a>
+                        <Link to="/subjects">
+                            Übersicht
+                        </Link>
+                        <span> / </span>
+                        <Link to=".">
+                            {subject?.name}
+                        </Link>
                     </p>
-                    <h2 style={{ marginBottom: "0.5em" }}>{subjectName}</h2>
+                    <h2 style={{ marginBottom: "0.5em" }}>{subject?.name}</h2>
                     {/* todo correct link */}
                     <p>
                         Detailliertere Informationen finden Sie im{" "}


### PR DESCRIPTION
The subject view was bugged and didn't show any information. This could now be observed, since the backend returns dummy data. Additionally, all links used an `<a>` element, which is undesirable, since it causes a full site refresh. All links related to the subject view now use the `Link` element from `react-router`.