### PR TITLE
fix: remove hardcoded backend url, use vite proxy

### DIFF
--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -18,7 +18,7 @@ import { Configuration } from "./configuration";
 // @ts-ignore
 import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
 
-export const BASE_PATH = "http://localhost:9090".replace(/\/+$/, "");
+export const BASE_PATH = "";
 
 /**
  *

--- a/frontend/src/components/pages/MyRegistrations.tsx
+++ b/frontend/src/components/pages/MyRegistrations.tsx
@@ -150,7 +150,7 @@ function MyRegistrations() {
                 .createNewRegistration({
                     student: user.idTokenParsed!.preferred_username,
                     subjectSelection: arr,
-                })
+                }, getRequestHeaders(user))
                 .then((response) => {
                     console.log("successful call");
                 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,4 +14,11 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:9090"
+      },
+    },
+  },
 });


### PR DESCRIPTION
fix: send auth token for createNewRegistration

This fixes the backend not being reachable when the server is deployed.
Also fixes 401 unauthorized status code when submitting the registration.